### PR TITLE
Changes for Zig v0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: master
       - run: zig fmt --check *.zig src/*.zig
 
   install-sh:
@@ -40,6 +40,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.12.0
+          version: master
       - run: zig build -Dtarget=${{ matrix.target }}
       - run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: "0.14.1"
       - run: zig fmt --check *.zig src/*.zig
 
   install-sh:
@@ -40,6 +40,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: "0.14.1"
       - run: zig build -Dtarget=${{ matrix.target }}
       - run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
           version: master
       - run: zig fmt --check *.zig src/*.zig
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
           version: master
       - run: zig build -Dtarget=${{ matrix.target }}

--- a/build.zig
+++ b/build.zig
@@ -21,12 +21,14 @@ pub fn build(b: *std.Build) !void {
             .strip = strip,
         }) },
     );
+    zigverm.subsystem = .Console;
     const zig = b.addExecutable(.{ .name = "zig", .root_module = b.createModule(.{
         .root_source_file = b.path("src/zig/main.zig"),
         .target = target,
         .optimize = optimize,
         .strip = strip,
     }) });
+    zig.subsystem = .Console;
 
     zigverm.root_module.addImport("common", common);
     // zigverm.root_module.addImport("zip", zip.module("zip"));

--- a/build.zig
+++ b/build.zig
@@ -5,8 +5,6 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const zip = b.dependency("zip", .{});
-
     const common = b.createModule(.{ .root_source_file = b.path("src/common/root.zig") });
     const default_os = target.result.os.tag;
     if (default_os.isBSD() or default_os.isDarwin() or default_os == std.Target.Os.Tag.linux) {
@@ -31,7 +29,7 @@ pub fn build(b: *std.Build) !void {
     });
 
     zigverm.root_module.addImport("common", common);
-    zigverm.root_module.addImport("zip", zip.module("zip"));
+    // zigverm.root_module.addImport("zip", zip.module("zip"));
     zig.root_module.addImport("common", common);
     b.installArtifact(zigverm);
     b.installArtifact(zig);

--- a/build.zig
+++ b/build.zig
@@ -13,20 +13,20 @@ pub fn build(b: *std.Build) !void {
 
     const strip = if (optimize == std.builtin.OptimizeMode.ReleaseSafe) true else null;
 
-    const zigverm = b.addExecutable(.{
-        .name = "zigverm",
-        .root_source_file = b.path("src/main.zig"),
+    const zigverm = b.addExecutable(
+        .{ .name = "zigverm", .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .strip = strip,
+        }) },
+    );
+    const zig = b.addExecutable(.{ .name = "zig", .root_module = b.createModule(.{
+        .root_source_file = b.path("src/zig/main.zig"),
         .target = target,
         .optimize = optimize,
         .strip = strip,
-    });
-    const zig = b.addExecutable(.{
-        .name = "zig",
-        .root_source_file = b.path("src/zig//main.zig"),
-        .target = target,
-        .optimize = optimize,
-        .strip = strip,
-    });
+    }) });
 
     zigverm.root_module.addImport("common", common);
     // zigverm.root_module.addImport("zip", zip.module("zip"));
@@ -57,25 +57,25 @@ fn addExeRunner(b: *std.Build, zigverm: *Compile, zig: *Compile) void {
 }
 
 fn addTestRunner(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) void {
-    const zigverm_tests = b.addTest(.{
+    const zigverm_tests = b.addTest(.{ .root_module = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
-    });
+    }) });
     const run_zigverm_tests = b.addRunArtifact(zigverm_tests);
 
-    const zig_tests = b.addTest(.{
+    const zig_tests = b.addTest(.{ .root_module = b.createModule(.{
         .root_source_file = b.path("src/zig/main.zig"),
         .target = target,
         .optimize = optimize,
-    });
+    }) });
     const run_zig_tests = b.addRunArtifact(zig_tests);
 
-    const common_tests = b.addTest(.{
-        .root_source_file = b.path("src/common/tests.zig"),
+    const common_tests = b.addTest(.{ .root_module = b.createModule(.{
+        .root_source_file = b.path("src/zig/main.zig"),
         .target = target,
         .optimize = optimize,
-    });
+    }) });
     const default_os = target.result.os.tag;
     if (default_os.isBSD() or default_os.isDarwin() or default_os == std.Target.Os.Tag.linux) {
         common_tests.linkLibC();

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,14 +1,8 @@
 .{
-    .name = "zigverm",
+    .name = .zigverm,
     .version = "0.6.2",
     .minimum_zig_version = "0.11.0",
-
-    .dependencies = .{
-        .zip = .{
-            .url = "git+https://github.com/AMythicDev/zip.zig#b1f8fe858943cb14eb333c7424bb23ae002ee7a1",
-            .hash = "1220130f0297f2c4cca318c6383758e5c1632467556147347af2c6a1214cab7a6ba4",
-        },
-    },
+    .fingerprint = 0xffdf55ceb1c7efde,
 
     .paths = .{
         "build.zig",

--- a/src/common/paths.zig
+++ b/src/common/paths.zig
@@ -76,7 +76,7 @@ pub fn home_dir(alloc: Allocator) ![]const u8 {
         } else |_| {
             switch (default_os) {
                 OsTag.linux, OsTag.openbsd => {
-                    return std.mem.span(std.c.getpwuid(getuid()).?.pw_dir.?);
+                    return std.mem.span(std.c.getpwuid(getuid()).?.dir.?);
                 },
                 else => {
                     @panic("Cannot determine home directory");

--- a/src/main.zig
+++ b/src/main.zig
@@ -202,7 +202,7 @@ fn installed_versions(alloc: Allocator, cp: CommonPaths) ![][]const u8 {
     var versions = std.ArrayList([]const u8).init(alloc);
     while (try iter.next()) |i| {
         if (!utils.check_install_name(i.name)) continue;
-        var components = std.mem.split(u8, i.name[4..], "-");
+        var components = std.mem.splitScalar(u8, i.name[4..], '-');
         _ = components.next();
         _ = components.next();
         const version = components.next() orelse unreachable;

--- a/src/main.zig
+++ b/src/main.zig
@@ -211,7 +211,7 @@ fn installed_versions(alloc: Allocator, cp: CommonPaths) ![][]const u8 {
     return versions.items;
 }
 
-fn get_version_from_exe(alloc: Allocator, release_name: []const u8) !std.ArrayList(u8) {
+fn get_version_from_exe(alloc: Allocator, release_name: []const u8) !std.ArrayListUnmanaged(u8) {
     var executable = [2][]const u8{ undefined, "version" };
     executable[0] = try std.fs.path.join(alloc, &.{
         common.paths.CommonPaths.get_zigverm_root(),
@@ -219,13 +219,13 @@ fn get_version_from_exe(alloc: Allocator, release_name: []const u8) !std.ArrayLi
         release_name,
         "zig",
     });
-    var version = std.ArrayList(u8).init(alloc);
-    var stderr = std.ArrayList(u8).init(alloc);
+    var version: std.ArrayListUnmanaged(u8) = .empty;
+    var stderr: std.ArrayListUnmanaged(u8) = .empty;
     var child = std.process.Child.init(&executable, alloc);
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
     try child.spawn();
-    try child.collectOutput(&version, &stderr, 256);
+    try child.collectOutput(alloc, &version, &stderr, 256);
     _ = try child.wait();
     _ = version.pop();
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -36,14 +36,14 @@ pub fn check_install_name(name: []const u8) bool {
 }
 
 pub inline fn is_valid_arch_os(arch: ?[]const u8, os: ?[]const u8) bool {
-    const arch_fields = @typeInfo(std.Target.Cpu.Arch).Enum.fields;
+    const arch_fields = @typeInfo(std.Target.Cpu.Arch).@"enum".fields;
     comptime var archs: [arch_fields.len][]const u8 = undefined;
     comptime {
         for (arch_fields, 0..) |a, i| {
             archs[i] = a.name;
         }
     }
-    const osfields = @typeInfo(std.Target.Os.Tag).Enum.fields;
+    const osfields = @typeInfo(std.Target.Os.Tag).@"enum".fields;
     comptime var oses: [osfields.len][]const u8 = undefined;
     comptime {
         for (osfields, 0..) |o, i| {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -19,7 +19,7 @@ pub fn check_install_name(name: []const u8) bool {
     if (!std.mem.startsWith(u8, name, "zig-")) {
         return false;
     }
-    var components = std.mem.split(u8, name[4..], "-");
+    var components = std.mem.splitScalar(u8, name[4..], '-');
 
     const arch = components.next();
     const os = components.next();


### PR DESCRIPTION
Zig v0.14 seems to introduce some API changes which causes zigverm builds to fail on it. This PR tracks all the changes and fixes needed to make zigverm compatible with Zig v0.14