### PR TITLE
Use cova

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const zip = b.dependency("zip", .{});
+    const cova = b.dependency("cova", .{});
 
     const common = b.createModule(.{ .root_source_file = b.path("src/common/root.zig") });
     const default_os = target.result.os.tag;
@@ -32,6 +33,7 @@ pub fn build(b: *std.Build) !void {
 
     zigverm.root_module.addImport("common", common);
     zigverm.root_module.addImport("zip", zip.module("zip"));
+    zigverm.root_module.addImport("cova", cova.module("cova"));
     zig.root_module.addImport("common", common);
     b.installArtifact(zigverm);
     b.installArtifact(zig);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,6 +8,10 @@
             .url = "https://github.com/AMythicDev/zip.zig/archive/refs/tags/v0.1.0.tar.gz",
             .hash = "1220b5e3ecda108ccae1749479ec7e02f1f2ddcbb8102a2b5a7cd92bc8aebb4d153d",
         },
+        .cova = .{
+            .url = "https://github.com/00JCIV00/cova/archive/refs/tags/v0.10.1-beta.tar.gz",
+            .hash = "12202782cc66e88f0c15b9acea9d6d1d50dbe941d68b5297927243f6d0377dbb1123",
+        },
     },
 
     .paths = .{

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -36,94 +36,82 @@ const helptext =
     \\      -V  --version        Print version info
 ;
 
-pub const OverrideArrgs = struct {
+const cova = @import("cova");
+pub const CommandT = cova.Command.Base();
+pub const OptionT = CommandT.OptionT;
+pub const ValueT = CommandT.ValueT;
+
+pub const Install = struct {
     version: []const u8,
-    directory: ?[]const u8,
 };
 
-pub const Cli = union(enum) {
-    install: []const u8,
-    remove: []const u8,
-    show,
-    update_self,
-    override: OverrideArrgs,
-    override_rm: ?[]const u8,
-    update: ?[]const u8,
-    std: ?[]const u8,
-    reference: ?[]const u8,
-
-    pub fn read_args(alloc: Allocator) anyerror!Cli {
-        var arg_iter = try std.process.argsWithAllocator(alloc);
-        defer arg_iter.deinit();
-
-        _ = arg_iter.next();
-
-        var command: Cli = undefined;
-
-        var cmd: []const u8 = undefined;
-
-        {
-            const trycmd = arg_iter.next();
-            if (trycmd) |c|
-                cmd = c
-            else
-                incorrectUsage(null);
-        }
-
-        if (streql(cmd, "install")) {
-            const rel = arg_iter.next().?;
-            command = Cli{ .install = try alloc.dupe(u8, rel) };
-        } else if (streql(cmd, "remove")) {
-            const rel = arg_iter.next().?;
-            command = Cli{ .remove = try alloc.dupe(u8, rel) };
-        } else if (streql(cmd, "update")) {
-            const rel = arg_iter.next();
-            command = Cli{ .update = if (rel) |r| try alloc.dupe(u8, r) else null };
-        } else if (streql(cmd, "std")) {
-            const rel = arg_iter.next();
-            command = Cli{ .std = if (rel) |r| try alloc.dupe(u8, r) else null };
-        } else if (streql(cmd, "reference")) {
-            const rel = arg_iter.next();
-            command = Cli{ .reference = if (rel) |r| try alloc.dupe(u8, r) else null };
-        } else if (streql(cmd, "info")) {
-            command = Cli.show;
-        } else if (streql(cmd, "-h") or streql(cmd, "--help")) {
-            utils.printStdOut("{s}\n", .{helptext});
-            std.process.exit(0);
-        } else if (streql(cmd, "-V") or streql(cmd, "--version")) {
-            utils.printStdOut("{s}\n", .{Version});
-            std.process.exit(0);
-        } else if (streql(cmd, "update-self")) {
-            command = Cli.update_self;
-        } else if (streql(cmd, "override")) {
-            const rel_or_directory = arg_iter.next() orelse return incorrectUsage(null);
-            const rel = arg_iter.next();
-
-            var override_args = OverrideArrgs{ .version = undefined, .directory = null };
-
-            if (rel != null) {
-                override_args.version = try alloc.dupe(u8, rel.?);
-                override_args.directory = try alloc.dupe(u8, rel_or_directory);
-            } else {
-                override_args.version = try alloc.dupe(u8, rel_or_directory);
-            }
-
-            command = Cli{ .override = override_args };
-        } else if (streql(cmd, "override-rm")) {
-            const directory = arg_iter.next() orelse return incorrectUsage(null);
-            command = Cli{ .override_rm = directory };
-        } else incorrectUsage(cmd);
-
-        return command;
-    }
+pub const Cli = CommandT{
+    .name = "zigverm",
+    .description = "A version manager for the Zig programming language",
+    .sub_cmds = &.{
+        .{
+            .name = "install",
+            .description = "Install a specific version",
+            .vals = &.{
+                ValueT.ofType([]const u8, .{ .name = "version", .description = "Version can be any valid semantic version or master or stable" }),
+            },
+        },
+        .{
+            .name = "remove",
+            .description = "Remove a already installed specific version.",
+            .vals = &.{
+                ValueT.ofType([]const u8, .{ .name = "version", .description = "Version can be any valid semantic version or master or stable" }),
+            },
+        },
+        .{
+            .name = "override",
+            .description = "Override the version of zig used",
+            .vals = &.{
+                ValueT.ofType([]const u8, .{ .name = "directory", .description = 
+                \\DIRECTORY can be 
+                \\                              - Path to a directory, under which to override
+                \\                              - "default", to change the default version
+                \\                              - ommited to use the current directory
+                , .default_val = "" }),
+                ValueT.ofType([]const u8, .{ .name = "version", .description = "Version can be any valid semantic version or master or stable" }),
+            },
+        },
+        .{
+            .name = "override-rm",
+            .description = "Override the version of zig used",
+            .vals = &.{
+                ValueT.ofType([]const u8, .{ .name = "directory", .description = "DIRECTORY should be path to a directory, for which to remove override" }),
+                ValueT.ofType([]const u8, .{ .name = "version", .description = "Version can be any valid semantic version or master or stable" }),
+            },
+        },
+        .{
+            .name = "std",
+            .description = "Open the standard library documentation in the default web browser.",
+            .vals = &.{
+                ValueT.ofType([]const u8, .{ .name = "version", .description = "Opens for this VERSION. If not specified, opens for the active Zig version in the current directory.", .default_val = "" }),
+            },
+        },
+        .{
+            .name = "reference",
+            .description = "Open the language reference in the default web browser.",
+            .vals = &.{
+                ValueT.ofType([]const u8, .{ .name = "version", .description = "Opens for this VERSION. If not specified, opens for the active version on the current directory.", .default_val = "" }),
+            },
+        },
+        .{
+            .name = "info",
+            .description = "Show information about installations",
+        },
+        .{
+            .name = "update-self",
+            .description = "Update zigverm itself",
+        },
+    },
 };
 
-fn incorrectUsage(cmd: ?[]const u8) noreturn {
-    if (cmd != null) {
-        std.debug.print("Incorrect usage for '{s}'. Please see help by using --help\n", .{cmd.?});
-        std.process.exit(1);
-    } else {
-        std.debug.print("Incorrect usage. Please see help by using --help\n", .{});
-        std.process.exit(1);
-    }
-}
+// ValueT.GenericT{
+//     .string, .{
+//         .name = "version",
+//         .description = "install",
+//     },
+// },

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -4,46 +4,10 @@ const streql = @import("common").streql;
 const Version = @import("main.zig").Version;
 const utils = @import("utils.zig");
 
-const helptext =
-    \\zigverm - A version manager for Zig
-    \\
-    \\zigverm [options] [command]
-    \\
-    \\Commands:
-    \\      install <version>                   Install a specific version. Version can be any valid semantic version
-    \\                                          or master or stable
-    \\      override [DIRECTORY] <version>      Override the version of zig used under DIRECTORY. DIRECTORY can be
-    \\                                              - Path to a directory, under which to override
-    \\                                              - "default", to change the default version
-    \\                                              - ommited to use the current directory
-    \\      override-rm <DIRECTORY>             Override the version of zig used under DIRECTORY. DIRECTORY should
-    \\                                          be path to a directory, for which to remove override
-    \\      update [VERSION]                    Update version to its latest available point release, If [VERSION] is
-    \\                                          not provided, it will update all installed versions
-    \\      update-self                         Update zigverm itself
-    \\      std [VERSION]                       Open the standard library documentation in the default web browser.
-    \\                                          If [VERSION] is specified, it will open the documentation for that version
-    \\                                          otherwise it will default to of the active version on the current directory.
-    \\      reference [VERSION]                 Open the language reference in the default web browser.
-    \\                                          If [VERSION] is specified, it will open the reference for that version
-    \\                                          otherwise it will default to of the active version on the current directory.
-    \\      remove <version>                    Remove a already installed specific version. Version can be any
-    \\                                          valid semantic version or master or stable
-    \\      info                                Show information about installations
-    \\
-    \\Options:
-    \\      -h  --help           Show this help message
-    \\      -V  --version        Print version info
-;
-
 const cova = @import("cova");
 pub const CommandT = cova.Command.Base();
 pub const OptionT = CommandT.OptionT;
 pub const ValueT = CommandT.ValueT;
-
-pub const Install = struct {
-    version: []const u8,
-};
 
 pub const Cli = CommandT{
     .name = "zigverm",
@@ -66,13 +30,21 @@ pub const Cli = CommandT{
         .{
             .name = "override",
             .description = "Override the version of zig used",
+            .opts = &.{OptionT{
+                .name = "directory",
+                .short_name = 'd',
+                .long_name = "dir",
+                .description =
+                \\ DIRECTORY can be
+                \\              - Path to a directory, under which to override
+                \\              - "default", to change the default version
+                \\              - ommited to use the current directory
+                ,
+                .val = ValueT.ofType([]const u8, .{
+                    .name = "directory",
+                }),
+            }},
             .vals = &.{
-                ValueT.ofType([]const u8, .{ .name = "directory", .description = 
-                \\DIRECTORY can be 
-                \\                              - Path to a directory, under which to override
-                \\                              - "default", to change the default version
-                \\                              - ommited to use the current directory
-                , .default_val = "" }),
                 ValueT.ofType([]const u8, .{ .name = "version", .description = "Version can be any valid semantic version or master or stable" }),
             },
         },
@@ -81,7 +53,6 @@ pub const Cli = CommandT{
             .description = "Override the version of zig used",
             .vals = &.{
                 ValueT.ofType([]const u8, .{ .name = "directory", .description = "DIRECTORY should be path to a directory, for which to remove override" }),
-                ValueT.ofType([]const u8, .{ .name = "version", .description = "Version can be any valid semantic version or master or stable" }),
             },
         },
         .{
@@ -108,10 +79,3 @@ pub const Cli = CommandT{
         },
     },
 };
-
-// ValueT.GenericT{
-//     .string, .{
-//         .name = "version",
-//         .description = "install",
-//     },
-// },

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -61,6 +61,7 @@ pub const Cli = CommandT{
             .vals = &.{
                 ValueT.ofType([]const u8, .{ .name = "version", .description = "Opens for this VERSION. If not specified, opens for the active Zig version in the current directory.", .default_val = "" }),
             },
+            .vals_mandatory = false,
         },
         .{
             .name = "reference",
@@ -68,6 +69,7 @@ pub const Cli = CommandT{
             .vals = &.{
                 ValueT.ofType([]const u8, .{ .name = "version", .description = "Opens for this VERSION. If not specified, opens for the active version on the current directory.", .default_val = "" }),
             },
+            .vals_mandatory = false,
         },
         .{
             .name = "info",


### PR DESCRIPTION
[cova](https://github.com/00JCIV00/cova) is a CLI library for written in Zig. It provides some great features which can give significant improvements over the very rudimentary interface that zigverm uses right now. 
This PR aims to port all zigverm CLI handling code with Cova. 

Much of the work regarding the command line interface is done. The main work now remains is to re-implement all the command matching code and minor improvement on the help texts.

- [x] Add Cova as dependency
- [x] Specify all previous CLI commands/positional arguments in Cova
- [ ] Re-implement the command matching logic (currently commented out)
- [ ] Improve the text display on usage help

Depends on 00JCIV00/cova#69